### PR TITLE
Added capability to change screnshot string

### DIFF
--- a/ModConfig.cs
+++ b/ModConfig.cs
@@ -9,9 +9,11 @@ namespace AutoFarmScreenshot
     class ModConfig
     {
         public float ScaleNumber { get; set; }
+        public string ScreenshotFormat { get; set; }
         public ModConfig()
         {
             this.ScaleNumber = 0.25f;
+            this.ScreenshotFormat = "{PlayerName}_{Season}_{Day}_{Year}";
         }
     }
 }

--- a/ModEntry.cs
+++ b/ModEntry.cs
@@ -13,6 +13,7 @@ namespace AutoFarmScreenshot
         private ModConfig Config;
         float scale = 0.25f;
         string screenshot_name = null;
+        string screenshot_format = null;
         IReflectedMethod takeMapscreenshot = null;
         IReflectedMethod addMessage = null;
         bool isScreenshottedToday = false;
@@ -29,6 +30,7 @@ namespace AutoFarmScreenshot
             // read config
             Config = Helper.ReadConfig<ModConfig>();
             scale = Config.ScaleNumber;
+            screenshot_format = Config.ScreenshotFormat;
             // attach event
             Helper.Events.GameLoop.SaveLoaded += GameLoop_SaveLoaded;
             Helper.Events.Player.Warped += Player_Warped;
@@ -42,7 +44,24 @@ namespace AutoFarmScreenshot
             nowInFarm = false;
             isScreenshottedToday = false;
             var SToday = SDate.Now();
-            screenshot_name = Game1.player.name + "_" + SToday.Season + "-" + SToday.Day + "-" + SToday.Year;
+            screenshot_name = Format_Screenshot_Name();
+        }
+
+        private string Format_Screenshot_Name()
+        {
+            string _screenshot_name = screenshot_format;
+            var screenshot_dict = new System.Collections.Generic.Dictionary<string, string> { 
+                { "{PlayerName}", Game1.player.name }, 
+                { "{Season}", SDate.Now().Season.ToString() },
+                { "{Day}", SDate.Now().Day.ToString("00") },
+                { "{Year}", SDate.Now().Year.ToString("00") },
+                { "{TotalDays}", SDate.Now().DaysSinceStart.ToString("0000") }
+            };
+            foreach(System.Collections.Generic.KeyValuePair<string, string> format_item in screenshot_dict)
+            {
+                _screenshot_name = _screenshot_name.Replace(format_item.Key, format_item.Value);
+            }
+            return _screenshot_name;
         }
 
         private void GameLoop_DayStarted(object sender, DayStartedEventArgs e)

--- a/ModEntry.cs
+++ b/ModEntry.cs
@@ -55,7 +55,8 @@ namespace AutoFarmScreenshot
                 { "{Season}", SDate.Now().Season.ToString() },
                 { "{Day}", SDate.Now().Day.ToString("00") },
                 { "{Year}", SDate.Now().Year.ToString("00") },
-                { "{TotalDays}", SDate.Now().DaysSinceStart.ToString("0000") }
+                { "{TotalDays}", SDate.Now().DaysSinceStart.ToString("0000") },
+                { "{FarmName}", Game1.player.farmName}
             };
             foreach(System.Collections.Generic.KeyValuePair<string, string> format_item in screenshot_dict)
             {

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Open config.json and change the values you would like to change
   * {Day} is replaced with the day of the season in 2 digit format (01, 05, 11)
   * {Year} is replaced with the current year in 2 digit format  (01, 05, 11)
   * {TotalDays} is replaced with the total number of days that have passed since Spring 1, Year 1 in 4 digit format (0001, 0023)
+  * Anything else is added literally to the screnshot name as is.
+  * I.E {PlayerName}_{Season}_{Day}_{Year} is turned into Bob_spring_03_01 for a character named Bob, on spring day 3, year 1
 
 ### NEXUS PAGE
 [AutoFarmScreenshot](https://www.nexusmods.com/stardewvalley/mods/4783/)

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ A Stardew Valley mod that help you automatically takes a screenshot of farm ever
 
 ### REQUIREMENTS :
 
-[SMAPI - Stardew Modding API 3.0.1+](https://github.com/Pathoschild/SMAPI)
+[SMAPI - Stardew Modding API 3.8.0+](https://github.com/Pathoschild/SMAPI)
 
 
-### HOW THIS MOD WORK :
+### HOW THIS MOD WORKS :
 
 With Stardew Valley 1.4 update it comes a new map export feature
 
@@ -30,13 +30,22 @@ Screenshots will be saved in "%appdata%\StardewValley\Screenshots". You can also
 
 ### CONFIG :
 
-Open the config.json and change the scale number with in (0, 1] (default: 0.25 means 25%)
+Open config.json and change the values you would like to change 
 
 ``` json
 {
-  "ScaleNumber": 0.25
+  "ScaleNumber": 0.25,
+  "ScreenshotFormat": "{PlayerName}_{Season}_{Day}_{Year}"
 }
 ```
+
+* ScaleNumber: the zoom scale for the [0, 1] (default: 0.25 is 25% zoom)
+* ScreenshotFormat: The formatting for the name of the screenshots being taken
+  * {PlayerName} is replaced with the Farmer's name
+  * {Season} is replaced with the name of the current season
+  * {Day} is replaced with the day of the season in 2 digit format (01, 05, 11)
+  * {Year} is replaced with the current year in 2 digit format  (01, 05, 11)
+  * {TotalDays} is replaced with the total number of days that have passed since Spring 1, Year 1 in 4 digit format (0001, 0023)
 
 ### NEXUS PAGE
 [AutoFarmScreenshot](https://www.nexusmods.com/stardewvalley/mods/4783/)

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Open config.json and change the values you would like to change
   * {Day} is replaced with the day of the season in 2 digit format (01, 05, 11)
   * {Year} is replaced with the current year in 2 digit format  (01, 05, 11)
   * {TotalDays} is replaced with the total number of days that have passed since Spring 1, Year 1 in 4 digit format (0001, 0023)
+  * {FarmName} is replaced by the name of the farm
   * Anything else is added literally to the screnshot name as is.
   * I.E {PlayerName}_{Season}_{Day}_{Year} is turned into Bob_spring_03_01 for a character named Bob, on spring day 3, year 1
 


### PR DESCRIPTION
Keeps the same default of `{PlayerName}_{Season}_{Day}_{Year}`, adds new options for
* FarmName
* TotalDays